### PR TITLE
Set full and verify flags when building Polygon packages

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -331,7 +331,10 @@ def create_polygon_problem(api: PolygonAPI, problem_code: str, task: MoodleTask)
         api.request("problem.saveTest", params)
 
     api.request("problem.commitChanges", {"problemId": problem_id, "minorChanges": False})
-    api.request("problem.buildPackage", {"problemId": problem_id, "full": False})
+    api.request(
+        "problem.buildPackage",
+        {"problemId": problem_id, "full": True, "verify": True},
+    )
     wait_for_package(api, problem_id)
 
     return problem_id


### PR DESCRIPTION
## Summary
- request full package builds when finalizing Polygon problems
- enable verification during package builds to satisfy API requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d511b194833382d979bf09f0edb9