### PR TITLE
Convert inline HTML math tags to LaTeX

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -156,6 +156,7 @@ def extract_text_sections(html: str) -> tuple[str, str, str]:
     html = re.sub(r"(?i)<br\s*/?>", "\n", html)
     html = re.sub(r"(?i)</(p|div|h4|h5)>", "\n", html)
     html = re.sub(r"(?i)<(p|div|h4|h5)[^>]*>", "", html)
+    html = _convert_inline_math_tags(html)
     html = re.sub(r"(?i)</?(span|strong|b|i)[^>]*>", "", html)
 
     text = unescape(html)
@@ -194,6 +195,20 @@ def extract_text_sections(html: str) -> tuple[str, str, str]:
     input_format = "\n".join(input_lines) if input_lines else "Входные данные отсутствуют"
     output_format = "\n".join(output_lines) if output_lines else "Выходные данные отсутствуют"
     return legend, input_format, output_format
+
+
+def _convert_inline_math_tags(html: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        content = match.group("content")
+        stripped = content.strip()
+        if not stripped:
+            return stripped
+        return f"${stripped}$"
+
+    pattern = re.compile(
+        r"(?is)<\s*(?P<tag>b|strong|i|em)\b[^>]*>(?P<content>.*?)<\s*/\s*(?P=tag)\s*>"
+    )
+    return re.sub(pattern, _replace, html)
 
 
 def _normalize_whitespace(value: str) -> str:


### PR DESCRIPTION
## Summary
- convert inline HTML formatting tags used for variables into LaTeX math delimiters before cleaning the statement
- ensure the resulting Polygon statement retains inline math expressions instead of losing emphasis tags

## Testing
- python -m compileall moodle2polygon.py

------
https://chatgpt.com/codex/tasks/task_e_68e1db79d4a48333a3d9204853fd255c