### PR TITLE
Improve heading parsing for Moodle IO sections

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -175,16 +175,19 @@ def extract_text_sections(html: str) -> tuple[str, str, str]:
     current = "legend"
     for line in lines:
         normalized = line.lower()
-        if normalized.startswith("вход") and "дан" in normalized:
+        normalized = re.sub(r"\s+", " ", normalized)
+        normalized = normalized.strip()
+        normalized_heading = normalized.lstrip(" :—-–•.$'\"()[]{}0123456789")
+        if normalized_heading.startswith("вход") and "дан" in normalized_heading:
             current = "input"
             continue
-        if normalized.startswith("input"):
+        if normalized_heading.startswith("input"):
             current = "input"
             continue
-        if normalized.startswith("выход") and "дан" in normalized:
+        if normalized_heading.startswith("выход") and "дан" in normalized_heading:
             current = "output"
             continue
-        if normalized.startswith("output"):
+        if normalized_heading.startswith("output"):
             current = "output"
             continue
 


### PR DESCRIPTION
## Summary
- normalize section headings when extracting legend/input/output text so leading punctuation does not break detection

## Testing
- python - <<'PY'
from moodle2polygon import parse_moodle_xml
contest, tasks = parse_moodle_xml('sample.xml')
print(tasks[0].input_format)
print(tasks[0].output_format)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e93dda16e4833390790f29a76db03e