### PR TITLE
Adjust handling of statement samples

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -429,13 +429,7 @@ def create_polygon_problem(api: PolygonAPI, problem_code: str, task: MoodleTask)
             "testSample": test.use_in_statements,
         }
         if test.use_in_statements:
-            params.update(
-                {
-                    "testUseInStatements": True,
-                    "testInputForStatements": test.input_data,
-                    "testOutputForStatements": test.output_data,
-                }
-            )
+            params["testUseInStatements"] = True
         api.request("problem.saveTest", params)
 
     logger.info("Committing changes for %s", problem_code)


### PR DESCRIPTION
## Summary
- stop sending explicit statement input and output for sample tests
- continue marking example tests for inclusion in statements

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ecd519299c833399aed4193d01c3eb