### PR TITLE
Handle checker selection for leading zero outputs

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -260,12 +260,20 @@ def _select_checker(task: MoodleTask) -> str:
     if not task.tests:
         return "std::lcmp.cpp"
 
-    words = _extract_words(task.tests[0].output_data)
-    if not words:
-        return "std::lcmp.cpp"
-    if all(_is_integer_token(word) for word in words):
+    all_words: list[str] = []
+    for test in task.tests:
+        stripped_output = test.output_data.lstrip()
+        if stripped_output.startswith("0"):
+            return "std::lcmp.cpp"
+
+        words = _extract_words(test.output_data)
+        if not words:
+            return "std::lcmp.cpp"
+        all_words.extend(words)
+
+    if all(_is_integer_token(word) for word in all_words):
         return "std::ncmp.cpp"
-    if all(_is_float_token(word) for word in words):
+    if all(_is_float_token(word) for word in all_words):
         return "std::rcmp9.cpp"
     return "std::lcmp.cpp"
 


### PR DESCRIPTION
## Summary
- ensure checker selection falls back to lcmp when any test output starts with a zero
- apply checker heuristics across all tests instead of only the first

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb0c6c3308333aa64ceda2b87051f)