### PR TITLE
Sanitize contest name fallback

### DIFF
--- a/moodle2polygon.py
+++ b/moodle2polygon.py
@@ -352,7 +352,9 @@ def parse_moodle_xml(path: str) -> tuple[str, list[MoodleTask]]:
         )
 
     if not contest_name:
-        contest_name = pathlib.Path(path).stem
+        contest_name = pathlib.Path(path).stem.lower()
+        contest_name = re.sub(r"[^a-z0-9-]", "-", contest_name)
+        contest_name = re.sub(r"-+", "-", contest_name).strip("-")
 
     return contest_name or "Moodle Contest", tasks
 


### PR DESCRIPTION
## Summary
- sanitize contest name fallback by deriving from the XML filename and replacing invalid characters with dashes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb7e10adc833389e45f2fcfdc1d54)